### PR TITLE
Document that "git-encrypted" needs to be built first

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ This repo contains several packages:
 
 ## Development
 
-To run this code locally, you need to build the `git-remote-helper` package first. It seems like with yarn v1 there is no way to specify the build order. Bottom line, this should get you running:
+To run this code locally, you need to build the `git-remote-helper` and `git-encrypted` packages first. It seems like with yarn v1 there is no way to specify the build order. Bottom line, this should get you running:
 
 - `yarn` - Install the dependencies for all packages
 - `yarn workspace git-remote-helper build` - Build the git-remote-helper package
+- `yarn workspace git-encrypted build` - Build the git-encrypted package
 - `yarn workspaces run build` - Build all packages
 
 ## Terminology


### PR DESCRIPTION
git-encrypted needs to be built first before running `yarn workspaces run build`. Otherwise, I get the following error on when running workspaces run build:

`(typescript) Error: /Users/johannes/coding/GenerousLabs/git-remote-encrypted/packages/git-encrypted-host-git-api/src/api.ts(2,35): semantic error TS2307: Cannot find module 'git-encrypted' or its corresponding type declarations.`